### PR TITLE
fix: Corrige erro de referência na função de contraste de cor das notas

### DIFF
--- a/src/script.js
+++ b/src/script.js
@@ -195,4 +195,17 @@ document.addEventListener('DOMContentLoaded', () => {
     app.init();
 
     console.log('MindBoard iniciado!');
+
+    // Função utilitária para contraste de cor
+    function getContrastYIQ(hexcolor) {
+        hexcolor = hexcolor.replace('#', '');
+        if (hexcolor.length === 3) {
+            hexcolor = hexcolor.split('').map(c => c + c).join('');
+        }
+        const r = parseInt(hexcolor.substr(0,2),16);
+        const g = parseInt(hexcolor.substr(2,2),16);
+        const b = parseInt(hexcolor.substr(4,2),16);
+        const yiq = ((r*299)+(g*587)+(b*114))/1000;
+        return (yiq >= 128) ? '#222' : '#fff';
+    }
 });


### PR DESCRIPTION
Este pull request adiciona uma função utilitária para calcular o contraste da cor ao event listener `DOMContentLoaded` em `src/script.js`.

* Adicionada a função `getContrastYIQ` para determinar uma cor de texto apropriada (seja `#222` ou `#fff`) com base no contraste YIQ de uma determinada cor hexadecimal. Essa função garante melhor legibilidade ao sobrepor texto em fundos coloridos.